### PR TITLE
fix: add Jinja newline control to prevent line breaking in sudoers template

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,9 +25,10 @@
 
     sudo_command_aliases:
       SHUTDOWN: ["/usr/sbin/reboot", "/usr/sbin/poweroff"]
+      FILTER: ["/usr/sbin/grep", "/usr/sbin/fgrep", "/usr/sbin/egrep"]
 
     sudo_rights:
-      allowrebootsudo:
+      allowrebootandfilter:
         - name: "TEST"
           no_passwd: true
           from_hosts: ALL
@@ -35,7 +36,14 @@
           as_group: ALL
           commands: SHUTDOWN
           state: present
-      allowtailsudo:
+        - name: "secondusersudo"
+          no_passwd: true
+          from_hosts: ALL
+          as_user: ALL
+          as_group: ALL
+          commands: FILTER
+          state: present
+      allowfirstusertail:
         - name: "firstusersudo"
           no_passwd: true
           from_hosts: ALL

--- a/molecule/default/tests/test_sudo.py
+++ b/molecule/default/tests/test_sudo.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python
 
+
 def test_if_sudo_package_is_installed(host):
     assert host.package("sudo").is_installed
+
 
 def test_sudoers_file_properties(host):
     _sudo_file_config = host.file("/etc/sudoers")
     assert _sudo_file_config.mode == 0o440
-    assert _sudo_file_config.user == 'root'
-    assert _sudo_file_config.group == 'root'
-    assert host.run('visudo -c').rc <= 0
+    assert _sudo_file_config.user == "root"
+    assert _sudo_file_config.group == "root"
+    assert host.run("visudo -c").rc <= 0
+
 
 def test_syntax_of_sudoers_files(host):
     _sudo_config_dir = "/etc/sudoers.d"
-    for file in  host.file(_sudo_config_dir).listdir():
-        assert host.run("visudo -cf {}/{}".format(_sudo_config_dir,file)).rc <= 0
+    for file in host.file(_sudo_config_dir).listdir():
+        assert host.run("visudo -cf {}/{}".format(_sudo_config_dir, file)).rc <= 0
 
-def test_if_sudo_commands_is_working(host):
-    _sudo_cmd = host.run("su - firstusersudo -c 'sudo tail /dev/null'")
-    assert _sudo_cmd.rc <= 0
+
+def test_if_sudo_command_working(host):
+    _sudo_cmd_check_tail = host.run("su - firstusersudo -c 'sudo tail /dev/null'")
+    assert _sudo_cmd_check_tail.rc <= 0

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -1,3 +1,4 @@
+# jinja2: lstrip_blocks: True
 ## {{ ansible_managed }}
 
 {%+ for line in item.value -%}
@@ -19,5 +20,5 @@
 {%- endif +%}
 {%- if _sudo_state_rights == "present" -%}
     {{ line.name }} {{ _sudo_run_from_hosts }}=({{ _sudo_run_as_user }}:{{ _sudo_run_as_group }}) {{ _sudo_use_nopasswd }}{{ _sudo_run_commands }}
-{%- endif -%}
+{% endif -%}
 {%- endfor -%}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the sudoer.j2 template to include proper newline characters after each sudoer entry. This change ensures that each entry in the generated sudoers file is on a separate line, maintaining the correct format.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous template configuration caused all entries to be concatenated on a single line, making the file hard to read and potentially causing issues with sudo configuration. By ensuring that each entry ends with a newline, the file remains readable and adheres to expected formatting standards.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By using molecule

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

#6 